### PR TITLE
Remove ambiguity from quiz on fetching data

### DIFF
--- a/content/1-basics/7-fetching-data-for-pages.js
+++ b/content/1-basics/7-fetching-data-for-pages.js
@@ -129,7 +129,7 @@ As you can see in the above \`getInitialProps\` function, it prints the number o
 Now, have a look at both the browser console and server console.
 Then reload the page.
 
-In what places have you seen the above message printed?
+Where did you see the above message printed _after_ page reload?
       `
     },
 


### PR DESCRIPTION
The question on the quiz for fetching data implies that the user may have seen the console log in both browser and server console. Which is true, it does show up in both over the course of the exercise.

However, the quiz result is setup such as to verify where the user has seen the console log last, which is on the server console after refresh.

~To fix this ambiguity there are two options:~
- ~leave the correct quiz answer as is and change the text of the question (which I did)~
- ~leave the question as is and change the correct quiz answer~

**Later edit**
Advancing to the next step in the lesson it turns out that the intention was indeed to verify that the log appears only on the server console. There's only one fix to the ambiguity, the one bundled in this PR.