### PR TITLE
Fix the default port number of `next start`

### DIFF
--- a/content/1-basics/9-deploying-a-nextjs-app.js
+++ b/content/1-basics/9-deploying-a-nextjs-app.js
@@ -62,7 +62,7 @@ For that, add the following npm script:
 }
 ~~~
 
-That will start our app in port 8000.
+That will start our app in port 3000.
 
 So, you can run the following commands to run our app in production:
 


### PR DESCRIPTION
`next start` uses port 3000 as default, right?