### PR TITLE
Add instructions to install express on deploy with a custom server

### DIFF
--- a/content/1-basics/9-deploying-a-nextjs-app.js
+++ b/content/1-basics/9-deploying-a-nextjs-app.js
@@ -219,7 +219,11 @@ git checkout .
 git checkout clean-urls-ssr
 ~~~
 
-In that, we use a custom server to run our app.
+In that, we use a custom server to run our app, so add Express into your app:
+
+~~~bash
+npm install --save express
+~~~
 
 ### Build the app
 


### PR DESCRIPTION
You are using a custom server with Express [here](https://learnnextjs.com/basics/deploying-a-nextjs-app/deploy-with-a-custom-server) but does not explain how to install it. I know it was explained in past steps but is was lost after change the branch.