### PR TITLE
Corrected typo on Basics-5

### DIFF
--- a/content/1-basics/5-clean-urls-with-route-masking.js
+++ b/content/1-basics/5-clean-urls-with-route-masking.js
@@ -68,7 +68,7 @@ import Link from 'next/link'
 
 const PostLink = (props) => (
   <li>
-    <Link as={\`/p/\${props.id}\`} href={\`/post?title=\${props.title}\`}>
+    <Link as={\`/p/\${props.title}\`} href={\`/post?title=\${props.title}\`}>
       <a>{props.title}</a>
     </Link>
   </li>
@@ -91,7 +91,7 @@ Have look at the following code block:
 ~~~js
 const PostLink = (props) => (
   <li>
-    <Link as={\`/p/\${props.id}\`} href={\`/post?title=\${props.title}\`}>
+    <Link as={\`/p/\${props.title}\`} href={\`/post?title=\${props.title}\`}>
       <a>{props.title}</a>
     </Link>
   </li>


### PR DESCRIPTION
Link examples are using `props.id` in route mask. Should be `props.title`